### PR TITLE
Immediately display player move

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
         "evancz/elm-html": "4.0.2 <= v < 5.0.0",
         "evancz/start-app": "2.0.2 <= v < 3.0.0",
         "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"

--- a/src/GameLogic/Update.elm
+++ b/src/GameLogic/Update.elm
@@ -1,16 +1,34 @@
-module GameLogic.Update (Action (MoveInput, Reset), update) where
+module GameLogic.Update (Action (ComputerMove, MoveInput, Reset), update) where
+
+import Effects exposing (Effects)
+import Task
 
 import GameLogic.ComputerPlayer as ComputerPlayer
+import GameLogic.HandleTurn as HandleTurn
 import GameModel exposing (Coordinates, GameState)
 
 
-type Action = MoveInput Coordinates | Reset
+type Action = MoveInput Coordinates | ComputerMove (Maybe Coordinates) | Reset
 
 
-update : Action -> GameState -> GameState
+update : Action -> GameState -> (GameState, Effects Action)
 update action gameState =
     case action of
         MoveInput coordinates ->
-            ComputerPlayer.makeMoveVsComputer coordinates gameState
+            let
+                nextGameState = HandleTurn.makeMove coordinates gameState
+            in
+                if nextGameState == gameState
+                    then ( nextGameState, Effects.none )
+                    else ( nextGameState, makeComputerMove nextGameState )
+        ComputerMove (Just coordinates) ->
+            ( HandleTurn.makeMove coordinates gameState, Effects.none )
+        ComputerMove Nothing ->
+            ( gameState, Effects.none )
         Reset ->
-            GameModel.initialGameState
+            ( GameModel.initialGameState, Effects.none )
+
+
+makeComputerMove : GameState -> Effects Action
+makeComputerMove gameState =
+    Effects.task (Task.map (ComputerMove << ComputerPlayer.bestMove) (Task.succeed gameState))

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,13 +1,25 @@
-import StartApp.Simple exposing (start)
+import Effects exposing (Never)
+import StartApp exposing (start)
+import Task
 
 import GameModel as Model
 import GameLogic.Update as Update
 import View.View as View
 
 
-main =
+app =
     start
-        { model = Model.initialGameState
+        { inputs = []
+        , init = (Model.initialGameState, Effects.none)
         , update = Update.update
         , view = View.render
         }
+
+
+main =
+    app.html
+
+
+port tasks : Signal (Task.Task Never ())
+port tasks =
+  app.tasks

--- a/tests/GameLogic/UpdateTests.elm
+++ b/tests/GameLogic/UpdateTests.elm
@@ -1,31 +1,88 @@
 module GameLogic.UpdateTests (all) where
 
-import ElmTest exposing (Test, assert, assertEqual, suite, test)
+import Effects exposing (Effects)
+import ElmTest exposing (Test, assert, assertEqual, assertNotEqual, suite, test)
+import Task
 
-import GameLogic.Update exposing (Action (MoveInput, Reset), update)
-import GameModel exposing (Coordinates, GameState, Player (X, O), Status (InProgress))
+import GameLogic.HandleTurn as HandleTurn
+import GameModel exposing (Coordinates, GameState, Move, Player (X, O), Status (InProgress))
 import TestHelpers exposing (x, o)
+
+import GameLogic.Update exposing (Action (ComputerMove, MoveInput, Reset), update)
+
+
+getGameState : ( GameState, Effects Action ) -> GameState
+getGameState ( gameState, _ ) = gameState
+
+
+getEffects : ( GameState, Effects Action ) -> Effects Action
+getEffects ( _, effects ) = effects
 
 
 all : Test
 all =
     suite "Updating the game state"
 
-        [ test "Returns initial game state when the Reset action is triggered" <|
-            assertEqual GameModel.initialGameState
-                <| update Reset
-                <| GameState 3 O [ x 0 0 ] InProgress
+        [ suite "When a Reset action is triggered"
 
-        , test "Makes a player move and computer move when the MoveInput action is triggered" <|
-            let
-                moves =
-                    [ x 0 0, x 0 1, o 0 2
-                    , o 1 0, o 1 1, x 1 2
-                    , x 2 0
-                    ]
-            in
-                assertEqual (x 2 2 :: o 2 1 :: moves)
-                    <| .movesSoFar
-                    <| update (MoveInput (Coordinates 2 1))
-                    <| GameState 3 O moves InProgress
+            [ test "Returns the initial game state with no effects" <|
+                assertEqual
+                    GameModel.initialGameState
+                    (getGameState (update Reset (GameState 3 O [ x 0 0 ] InProgress)))
+
+            , test "Triggers no effects" <|
+                assertEqual
+                    Effects.none
+                    (getEffects (update Reset (GameState 3 O [ x 0 0 ] InProgress)))
+            ]
+
+        , suite "When a MoveInput action is triggered"
+
+            [ test "Makes a player move at the given coordinates" <|
+                let
+                    coordinates = Coordinates 1 1
+                    gameState = GameState 3 X [] InProgress
+                in
+                    assertEqual
+                        (HandleTurn.makeMove coordinates gameState)
+                        (getGameState (update (MoveInput coordinates) gameState))
+
+            , test "Triggers a ComputerMove action if the move was valid" <|
+                assertNotEqual Effects.none
+                    <| getEffects
+                    <| update (MoveInput (Coordinates 0 0))
+                    <| GameState 3 X [] InProgress
+
+            , test "Triggers nothing if the move was invalid" <|
+                assertEqual Effects.none
+                    <| getEffects
+                    <| update (MoveInput (Coordinates 0 0))
+                    <| GameState 3 O [ x 0 0] InProgress
+            ]
+
+        , suite "When a ComputerMove action is triggered"
+
+            [ test "Makes the computer move if given coordinates" <|
+                let
+                    coordinates = Coordinates 1 1
+                    gameState = GameState 3 X [] InProgress
+                in
+                    assertEqual
+                        (HandleTurn.makeMove coordinates gameState)
+                        (getGameState (update (ComputerMove (Just coordinates)) gameState))
+
+            , test "Changes nothing if not given coordinates" <|
+                let
+                    gameState = GameState 3 X [] InProgress
+                in
+                    assertEqual
+                        gameState
+                        (getGameState (update (ComputerMove Nothing) gameState))
+
+            , test "Triggers no effects" <|
+                assertEqual Effects.none
+                    <| getEffects
+                    <| update (ComputerMove (Just (Coordinates 0 0)))
+                    <| GameState 3 X [] InProgress
+            ]
         ]


### PR DESCRIPTION
- Previously, the player's move would not be displayed until the
  computer's move was made.
