### PR TITLE
Fix potential for players to switch roles

### DIFF
--- a/src/GameLogic/Update.elm
+++ b/src/GameLogic/Update.elm
@@ -17,18 +17,21 @@ update action gameState =
         MoveInput coordinates ->
             let
                 nextGameState = HandleTurn.makeMove coordinates gameState
-                effects =
-                    if nextGameState == gameState
-                        then Effects.none
-                        else makeComputerMove nextGameState
             in
-                ( nextGameState, effects )
+                if gameState.isComputerTurn || nextGameState == gameState
+                    then ( gameState, Effects.none )
+                    else ( { nextGameState | isComputerTurn = True }, makeComputerMove nextGameState )
         ComputerMove (Just coordinates) ->
-            ( HandleTurn.makeMove coordinates gameState, Effects.none )
+            let
+                nextGameState = HandleTurn.makeMove coordinates gameState
+            in
+                ( { nextGameState | isComputerTurn = False }, Effects.none )
         ComputerMove Nothing ->
-            ( gameState, Effects.none )
+            ( { gameState | isComputerTurn = False }, Effects.none )
         Reset ->
-            ( GameModel.initialGameState, Effects.none )
+            if gameState.isComputerTurn
+                then ( gameState, Effects.none )
+                else ( GameModel.initialGameState, Effects.none )
 
 
 makeComputerMove : GameState -> Effects Action

--- a/src/GameModel.elm
+++ b/src/GameModel.elm
@@ -30,6 +30,7 @@ type alias Move =
 
 type alias GameState =
     { boardSize : Int
+    , isComputerTurn : Bool
     , currentPlayer : Player
     , movesSoFar : List Move
     , status : Status
@@ -38,7 +39,7 @@ type alias GameState =
 
 initialGameState : GameState
 initialGameState =
-    GameState 3 X [] InProgress
+    GameState 3 False X [] InProgress
 
 
 boardCoordinates : GameState -> List Coordinates

--- a/tests/GameLogic/ComputerPlayerTests.elm
+++ b/tests/GameLogic/ComputerPlayerTests.elm
@@ -21,7 +21,7 @@ all =
                     , x 2 0, o 2 1, x 2 2
                     ]
             in
-                assertEqual Nothing (bestMove (GameState 3 X moves Tied))
+                assertEqual Nothing (bestMove (GameState 3 False X moves Tied))
 
         , test "Chooses a winning move" <|
             let
@@ -31,7 +31,9 @@ all =
                     , o 2 0
                     ]
             in
-                assertEqual (Just (Coordinates 0 2)) (bestMove (GameState 3 X moves InProgress))
+                assertEqual
+                    (Just (Coordinates 0 2))
+                    (bestMove (GameState 3 False X moves InProgress))
 
         , test "Chooses a move that blocks the opponent from winning" <|
             let
@@ -41,7 +43,9 @@ all =
                     , x 2 0
                     ]
             in
-                assertEqual (Just (Coordinates 1 2)) (bestMove (GameState 3 X moves InProgress))
+                assertEqual
+                    (Just (Coordinates 1 2))
+                    (bestMove (GameState 3 False X moves InProgress))
 
         , test "Chooses a move that creates a fork" <|
             let
@@ -51,7 +55,9 @@ all =
                     , x 2 0, o 2 1
                     ]
             in
-                assertEqual (Just (Coordinates 1 1)) (bestMove (GameState 3 X moves InProgress))
+                assertEqual
+                    (Just (Coordinates 1 1))
+                    (bestMove (GameState 3 False X moves InProgress))
 
         , test "Chooses a winning move over a blocking move" <|
             let
@@ -60,7 +66,9 @@ all =
                     , o 1 0, o 1 1
                     ]
             in
-                assertEqual (Just (Coordinates 0 2)) (bestMove (GameState 3 X moves InProgress))
+                assertEqual
+                    (Just (Coordinates 0 2))
+                    (bestMove (GameState 3 False X moves InProgress))
 
         , test "Chooses a winning move over a fork" <|
             let
@@ -69,7 +77,9 @@ all =
                     , x 1 0
                     ]
             in
-                assertEqual (Just (Coordinates 2 0)) (bestMove (GameState 3 X moves InProgress))
+                assertEqual
+                    (Just (Coordinates 2 0))
+                    (bestMove (GameState 3 False X moves InProgress))
 
         , test "Chooses a blocking move over a fork" <|
             let
@@ -78,7 +88,9 @@ all =
                     , o 1 0
                     ]
             in
-                assertEqual (Just (Coordinates 2 0)) (bestMove (GameState 3 X moves InProgress))
+                assertEqual
+                    (Just (Coordinates 2 0))
+                    (bestMove (GameState 3 False X moves InProgress))
 
         , test "Avoids making a move that results in a sure loss - scenario 1" <|
             let
@@ -86,7 +98,7 @@ all =
             in
                 assertNotEqual
                     (Just (Coordinates 2 2))
-                    (bestMove (GameState 3 O [ x 0 1, o 2 1, x 1 0 ] InProgress))
+                    (bestMove (GameState 3 False O [ x 0 1, o 2 1, x 1 0 ] InProgress))
 
         , test "Avoids making a move that results in a sure loss - scenario 2" <|
             let
@@ -94,7 +106,7 @@ all =
             in
                 assertNotEqual
                     (Just (Coordinates 1 0))
-                    (bestMove (GameState 3 O moves InProgress))
+                    (bestMove (GameState 3 False O moves InProgress))
 
         , test "Avoids making a move that results in a sure loss - scenario 3" <|
             let
@@ -102,5 +114,5 @@ all =
             in
                 assertNotEqual
                     (Just (Coordinates 2 2))
-                    (bestMove (GameState 3 O moves InProgress))
+                    (bestMove (GameState 3 False O moves InProgress))
         ]

--- a/tests/GameLogic/GameEndTests.elm
+++ b/tests/GameLogic/GameEndTests.elm
@@ -20,7 +20,7 @@ all =
                         [ x 0 0, x 0 1, x 0 2
                         , o 1 0, o 1 1
                         ]
-                    gameState = GameState 3 O moves (Won X)
+                    gameState = GameState 3 False O moves (Won X)
                 in
                     assertEqual True (isGameOver gameState)
 
@@ -32,10 +32,10 @@ all =
                         , x 2 0, o 2 1, x 2 2
                         ]
                 in
-                    assertEqual True (isGameOver (GameState 3 O moves Tied))
+                    assertEqual True (isGameOver (GameState 3 False O moves Tied))
 
             , test "Returns false if no moves have been made" <|
-                assertEqual False (isGameOver (GameState 3 X [] InProgress))
+                assertEqual False (isGameOver (GameState 3 False X [] InProgress))
 
             , test "Returns false if the game has not been won or tied" <|
                 let
@@ -43,9 +43,9 @@ all =
                         [ x 0 0, o 0 1, x 0 2
                         , o 1 0, x 1 1
                         ]
-                    gameState = GameState 3 O moves InProgress
+                    gameState = GameState 3 False O moves InProgress
                 in
-                    assertEqual False (isGameOver (GameState 3 O moves InProgress))
+                    assertEqual False (isGameOver (GameState 3 False O moves InProgress))
 
             , test "Result does not depend on game status" <|
                 let
@@ -54,14 +54,14 @@ all =
                         , o 1 0, x 1 1
                         ]
                     gameStates =
-                        List.map (GameState 3 O moves) [ InProgress, Tied, (Won X), (Won O) ]
+                        List.map (GameState 3 False O moves) [ InProgress, Tied, (Won X), (Won O) ]
                 in
                     assert (List.all (not << isGameOver) gameStates)
             ]
         , suite "Getting the winning player"
 
             [ test "Returns nothing if the game is not over" <|
-                assertEqual Nothing (winningPlayer (GameState 3 X [] InProgress))
+                assertEqual Nothing (winningPlayer (GameState 3 False X [] InProgress))
 
             , test "Returns nothing if the game is tied" <|
                 let
@@ -71,7 +71,7 @@ all =
                         , x 2 0, o 2 1, x 2 2
                         ]
                 in
-                    assertEqual Nothing (winningPlayer (GameState 3 X moves Tied))
+                    assertEqual Nothing (winningPlayer (GameState 3 False X moves Tied))
 
             , test "Returns player X if they won the game" <|
                 let
@@ -80,7 +80,7 @@ all =
                         , o 1 0, o 1 1
                         ]
                 in
-                    assertEqual (Just X) (winningPlayer (GameState 3 O moves (Won X)))
+                    assertEqual (Just X) (winningPlayer (GameState 3 False O moves (Won X)))
 
             , test "Returns player O if they won the game" <|
                 let
@@ -89,7 +89,7 @@ all =
                         , x 1 0, x 1 1
                         ]
                 in
-                assertEqual (Just O) (winningPlayer (GameState 3 X moves (Won O)))
+                assertEqual (Just O) (winningPlayer (GameState 3 False X moves (Won O)))
 
             , test "Result does not depend on game status" <|
                 let
@@ -98,7 +98,7 @@ all =
                         , o 1 0, x 1 1
                         ]
                     gameStates =
-                        List.map (GameState 3 O moves) [ InProgress, Tied, (Won X), (Won O) ]
+                        List.map (GameState 3 False O moves) [ InProgress, Tied, (Won X), (Won O) ]
                 in
                     assert (List.all (\state -> (winningPlayer state) == Nothing) gameStates)
 

--- a/tests/GameLogic/HandleTurnTests.elm
+++ b/tests/GameLogic/HandleTurnTests.elm
@@ -24,29 +24,29 @@ all =
                 assertEqual [ Move (Coordinates 0 0) X ]
                     <| .movesSoFar
                     <| makeMove (Coordinates 0 0)
-                    <| GameState 3 X [] InProgress
+                    <| GameState 3 False X [] InProgress
 
             , test "Returns a game state in which the next player is now the current player" <|
                 assertEqual (nextPlayer X)
                     <| .currentPlayer
                     <| makeMove (Coordinates 0 0)
-                    <| GameState 3 X [] InProgress
+                    <| GameState 3 False X [] InProgress
 
             , test "Does not make move if a move already exists at coordinates" <|
                 let
-                    gameState = GameState 3 O [ Move (Coordinates 0 0) X ] InProgress
+                    gameState = GameState 3 False O [ Move (Coordinates 0 0) X ] InProgress
                 in
                     assertEqual gameState (makeMove (Coordinates 0 0) gameState)
 
             , test "Does not make move if given game state status is Tied" <|
                 let
-                    gameState = GameState 3 X [] Tied
+                    gameState = GameState 3 False X [] Tied
                 in
                     assertEqual gameState (makeMove (Coordinates 0 0) gameState)
 
             , test "Does not make move if given game state status is Won" <|
                 let
-                    gameState = GameState 3 X [] (Won X)
+                    gameState = GameState 3 False X [] (Won X)
                 in
                     assertEqual gameState (makeMove (Coordinates 0 0) gameState)
 
@@ -56,7 +56,7 @@ all =
                     assertEqual InProgress
                         <| .status
                         <| makeMove (Coordinates 0 0)
-                        <| GameState 3 X [] InProgress
+                        <| GameState 3 False X [] InProgress
 
                 , test "Game has status Tied if game is tied after move is made" <|
                     let
@@ -69,7 +69,7 @@ all =
                         assertEqual Tied
                             <| .status
                             <| makeMove (Coordinates 2 2)
-                            <| GameState 3 X moves InProgress
+                            <| GameState 3 False X moves InProgress
 
                 , test "Game has status Won X if player X won the game" <|
                     let
@@ -81,7 +81,7 @@ all =
                         assertEqual (Won X)
                             <| .status
                             <| makeMove (Coordinates 0 2)
-                            <| GameState 3 X moves InProgress
+                            <| GameState 3 False X moves InProgress
 
                 , test "Game has status Won O if player O won the game" <|
                     let
@@ -93,7 +93,7 @@ all =
                         assertEqual (Won O)
                             <| .status
                             <| makeMove (Coordinates 0 2)
-                            <| GameState 3 O moves InProgress
+                            <| GameState 3 False O moves InProgress
                 ]
             , suite "Getting the next player"
 

--- a/tests/GameLogic/UpdateTests.elm
+++ b/tests/GameLogic/UpdateTests.elm
@@ -28,12 +28,18 @@ all =
             [ test "Returns the initial game state with no effects" <|
                 assertEqual
                     GameModel.initialGameState
-                    (getGameState (update Reset (GameState 3 O [ x 0 0 ] InProgress)))
+                    (getGameState (update Reset (GameState 3 False O [ x 0 0 ] InProgress)))
+
+            , test "Changes nothing if it is the computer's turn" <|
+                let
+                    gameState = GameState 3 True X [ x 1 1 ] InProgress
+                in
+                    assertEqual gameState (getGameState (update Reset gameState))
 
             , test "Triggers no effects" <|
                 assertEqual
                     Effects.none
-                    (getEffects (update Reset (GameState 3 O [ x 0 0 ] InProgress)))
+                    (getEffects (update Reset (GameState 3 False O [ x 0 0 ] InProgress)))
             ]
 
         , suite "When a MoveInput action is triggered"
@@ -41,23 +47,46 @@ all =
             [ test "Makes a player move at the given coordinates" <|
                 let
                     coordinates = Coordinates 1 1
-                    gameState = GameState 3 X [] InProgress
+                    gameState = GameState 3 False X [] InProgress
+                in
+                    assertEqual [ (x 1 1) ]
+                        <| .movesSoFar
+                        <| getGameState
+                        <| update (MoveInput coordinates) gameState
+
+            , test "Changes nothing if it is the computer's turn" <|
+                let
+                    gameState = GameState 3 True X [ x 1 1 ] InProgress
                 in
                     assertEqual
-                        (HandleTurn.makeMove coordinates gameState)
-                        (getGameState (update (MoveInput coordinates) gameState))
+                        gameState
+                        (getGameState (update (MoveInput (Coordinates 0 0)) gameState))
+
+            , test "Returns a game state where it is the computer's turn if move was valid" <|
+                assertEqual True
+                    <| .isComputerTurn
+                    <| getGameState
+                    <| update (MoveInput (Coordinates 0 0))
+                    <| GameState 3 False X [] InProgress
+
+            , test "Returns a game state where it is not the computer's turn if move was invalid" <|
+                assertEqual False
+                    <| .isComputerTurn
+                    <| getGameState
+                    <| update (MoveInput (Coordinates 0 0))
+                    <| GameState 3 False X [ x 0 0 ] InProgress
 
             , test "Triggers a ComputerMove action if the move was valid" <|
                 assertNotEqual Effects.none
                     <| getEffects
                     <| update (MoveInput (Coordinates 0 0))
-                    <| GameState 3 X [] InProgress
+                    <| GameState 3 False X [] InProgress
 
             , test "Triggers nothing if the move was invalid" <|
                 assertEqual Effects.none
                     <| getEffects
                     <| update (MoveInput (Coordinates 0 0))
-                    <| GameState 3 O [ x 0 0] InProgress
+                    <| GameState 3 False O [ x 0 0 ] InProgress
             ]
 
         , suite "When a ComputerMove action is triggered"
@@ -65,15 +94,22 @@ all =
             [ test "Makes the computer move if given coordinates" <|
                 let
                     coordinates = Coordinates 1 1
-                    gameState = GameState 3 X [] InProgress
+                    gameState = GameState 3 False X [] InProgress
                 in
                     assertEqual
                         (HandleTurn.makeMove coordinates gameState)
                         (getGameState (update (ComputerMove (Just coordinates)) gameState))
 
+            , test "Returns a game state where it is no longer the computer's turn" <|
+                assertEqual False
+                    <| .isComputerTurn
+                    <| getGameState
+                    <| update (ComputerMove (Just (Coordinates 0 0)))
+                    <| GameState 3 True X [] InProgress
+
             , test "Changes nothing if not given coordinates" <|
                 let
-                    gameState = GameState 3 X [] InProgress
+                    gameState = GameState 3 False X [] InProgress
                 in
                     assertEqual gameState (getGameState (update (ComputerMove Nothing) gameState))
 
@@ -81,6 +117,6 @@ all =
                 assertEqual Effects.none
                     <| getEffects
                     <| update (ComputerMove (Just (Coordinates 0 0)))
-                    <| GameState 3 X [] InProgress
+                    <| GameState 3 False X [] InProgress
             ]
         ]

--- a/tests/GameModelTests.elm
+++ b/tests/GameModelTests.elm
@@ -19,7 +19,7 @@ all =
         [ suite "Getting the board coordinates"
 
             [ test "A 3x3 board has 9 coordinates" <|
-                assertEqual 9 (List.length (boardCoordinates (GameState 3 X [] InProgress)))
+                assertEqual 9 (List.length (boardCoordinates (GameState 3 False X [] InProgress)))
 
             , test "A 3x3 board has coordinates from [0,0] to [2,2]" <|
                 let
@@ -29,18 +29,18 @@ all =
                         , (Coordinates 2 0), (Coordinates 2 1), (Coordinates 2 2)
                         ]
                 in
-                    assertEqual coordinates (boardCoordinates (GameState 3 X [] InProgress))
+                    assertEqual coordinates (boardCoordinates (GameState 3 False X [] InProgress))
             ]
         , suite "Getting the player who made a move" <|
 
             [ test "Returns Nothing if the is no move at the given coordinates" <|
                 assertEqual Nothing
                     <| playerAt (Coordinates 0 0)
-                    <| GameState 3 X [] InProgress
+                    <| GameState 3 False X [] InProgress
 
             , test "Returns the player who moved at the given coordinates" <|
                 assertEqual (Just X)
                     <| playerAt (Coordinates 0 0)
-                    <| GameState 3 X [ Move (Coordinates 0 0) X ] InProgress
+                    <| GameState 3 False X [ Move (Coordinates 0 0) X ] InProgress
             ]
         ]


### PR DESCRIPTION
- Due to some interaction between the async handling of the computer
  move and the queueing of multiple move inputs by the player, when
  a player queued multiple moves and one of those moves ended up
  being taken by a computer move, it was possible for players to
  switch roles between player X and player O.
- Additionally, it was possible to reset the game after queueing
  several moves, which would occasionally lead to the reset game
  state beginning with the computer in the role of player X.
- Added a flag that indicates whether the computer is making a move,
  and prevent additional move inputs or a game reset being made
  while that is true.
